### PR TITLE
Fix doctest after renaming to __init__.py

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -632,7 +632,7 @@ def ls(d, *globs):
 
     The pathnames in the result list contain the directory part `d`.
 
-    >>> '../src/shell.py' in ls('../src/', '*.py', '*.txt')
+    >>> '../src/__init__.py' in ls('../src/', '*.py', '*.txt')
     True
     """
     res = []


### PR DESCRIPTION
`src/shell.py` got renamed to `src/__init_.py` with 5e1c5491.