### PR TITLE
Fix _handleCapture for False

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -197,7 +197,7 @@ def _handleCapture(capture: CaptureType) -> Optional[_FILE]:
         return subprocess.PIPE
     elif callable(capture):
         return subprocess.PIPE
-    elif capture is None:
+    elif capture == False:
         return None
     else:
         return capture


### PR DESCRIPTION
`False` should not be passed to `stdout` in `subprocess.run` (called in `run`). As `False` is an instance of `int`, it would be treated as a file descriptor as far as I was able to tell.

Interestingly, this was only actually causing an issue (from what I've seen) when the tests were running with the CI of Alpine Linux. I guess that's because stdin might be connected to /dev/null there...